### PR TITLE
Adding new configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ then be removed after a click outside has occurred.
 
 Default: `false`
 
+#### `clickoutsideevents`
+
+By default, the outside click event is triggered on `click`. This property allows for a comma-separated list of events to cause the trigger.
+
+Example: For mobile support add:
+`[clickoutsideevents]="'click touchstart'"`
+
+Example: For mobile exclusive support add:
+`[clickoutsideevents]="'touchstart'"`
+
 #### `exclude`
 
-A comma-seperated string of DOM element queries to exclude when clicking outside of the element. For example: `[exclude]="'button,.btn-primary'"`.
+A comma-separated string of DOM element queries to exclude when clicking outside of the element. For example: `[exclude]="'button,.btn-primary'"`.
+
+#### `excludebeforeclick`
+
+By default clickOutside registers excluded DOM elements on init. This property refreshes the list before the clickOutside event is triggered. This is useful for ensuring that excluded elements added to the DOM after init are excluded (e.g. ng2-bootstrap popover: this allows for clicking inside the `.popover-content` area if specified in `exclude`)
+
+Default: `false`

--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ then be removed after a click outside has occurred.
 
 Default: `false`
 
-#### `clickoutsideevents`
+#### `clickOutsideEvents`
 
-By default, the outside click event is triggered on `click`. This property allows for a comma-separated list of events to cause the trigger.
+By default, the outside click event is triggered on `click`. This property allows for a space-separated list of events to cause the trigger.
 
 Example: For mobile support add:
-`[clickoutsideevents]="'click touchstart'"`
+`[clickOutsideEvents]="'click touchstart'"`
 
 Example: For mobile exclusive support add:
-`[clickoutsideevents]="'touchstart'"`
+`[clickOutsideEvents]="'touchstart'"`
 
 #### `exclude`
 
 A comma-separated string of DOM element queries to exclude when clicking outside of the element. For example: `[exclude]="'button,.btn-primary'"`.
 
-#### `excludebeforeclick`
+#### `excludeBeforeClick`
 
 By default clickOutside registers excluded DOM elements on init. This property refreshes the list before the clickOutside event is triggered. This is useful for ensuring that excluded elements added to the DOM after init are excluded (e.g. ng2-bootstrap popover: this allows for clicking inside the `.popover-content` area if specified in `exclude`)
 

--- a/src/click-outside.directive.ts
+++ b/src/click-outside.directive.ts
@@ -16,8 +16,8 @@ import { DOCUMENT } from '@angular/platform-browser';
 export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
   @Input() attachOutsideOnClick: boolean = false;
   @Input() exclude: string = '';
-  @Input() excludebeforeclick: boolean = false;
-  @Input() clickoutsideevents: string = '';
+  @Input() excludeBeforeClick: boolean = false;
+  @Input() clickOutsideEvents: string = '';
 
   @Output() clickOutside: EventEmitter<Event> = new EventEmitter<Event>();
 
@@ -50,8 +50,8 @@ export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   private _init() {
-    if (this.clickoutsideevents !== '') {
-      this._events = this.clickoutsideevents.split(' ');
+    if (this.clickOutsideEvents !== '') {
+      this._events = this.clickOutsideEvents.split(' ');
     }
     this._excludeCheck();
 
@@ -84,14 +84,15 @@ export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   private _onClickBody(e: Event) {
-    if (this.excludebeforeclick) {
+    if (this.excludeBeforeClick) {
       this._excludeCheck();
     }
     if (!this._el.nativeElement.contains(e.target) && !this._shouldExclude(e.target)) {
       this.clickOutside.emit(e);
 
       if (this.attachOutsideOnClick) {
-        this._events.forEach(event => this._document.body.removeEventListener(event, this._onClickBody));
+        this._document.body.removeEventListener('click', this._onClickBody);
+        this._document.body.removeEventListener('touchstart', this._onClickBody);
       }
     }
   }

--- a/src/click-outside.directive.ts
+++ b/src/click-outside.directive.ts
@@ -91,8 +91,7 @@ export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
       this.clickOutside.emit(e);
 
       if (this.attachOutsideOnClick) {
-        this._document.body.removeEventListener('click', this._onClickBody);
-        this._document.body.removeEventListener('touchstart', this._onClickBody);
+        this._events.forEach(event => this._document.body.removeEventListener(event, this._onClickBody));
       }
     }
   }

--- a/src/click-outside.directive.ts
+++ b/src/click-outside.directive.ts
@@ -16,10 +16,13 @@ import { DOCUMENT } from '@angular/platform-browser';
 export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
   @Input() attachOutsideOnClick: boolean = false;
   @Input() exclude: string = '';
+  @Input() excludebeforeclick: boolean = false;
+  @Input() clickoutsideevents: string = '';
 
   @Output() clickOutside: EventEmitter<Event> = new EventEmitter<Event>();
 
   private _nodesExcluded: Array<HTMLElement> = [];
+  private _events: Array<string> = ['click'];
 
   constructor(
     @Inject(DOCUMENT) private _document /*: HTMLDocument*/,
@@ -34,12 +37,10 @@ export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy() {
     if (this.attachOutsideOnClick) {
-      this._el.nativeElement.removeEventListener('click', this._initOnClickBody);
-      this._el.nativeElement.removeEventListener('touchstart', this._initOnClickBody);
+      this._events.forEach(event => this._el.nativeElement.removeEventListener(event, this._initOnClickBody));
     }
 
-    this._document.body.removeEventListener('click', this._onClickBody);
-    this._document.body.removeEventListener('touchstart', this._onClickBody);
+    this._events.forEach(event => this._document.body.removeEventListener(event, this._onClickBody));
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -49,6 +50,25 @@ export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
   }
 
   private _init() {
+    if (this.clickoutsideevents !== '') {
+      this._events = this.clickoutsideevents.split(' ');
+    }
+    this._excludeCheck();
+
+    if (this.attachOutsideOnClick) {
+      this._events.forEach(event => this._el.nativeElement.addEventListener(event, this._initOnClickBody));
+    } else {
+      this._initOnClickBody();
+    }
+  }
+
+  /** @internal */
+  private _initOnClickBody() {
+    this._events.forEach(event => this._document.body.addEventListener(event, this._onClickBody));
+  }
+
+  /** @internal */
+  private _excludeCheck() {
     if (this.exclude) {
       try {
         const nodes = this._document.querySelectorAll(this.exclude);
@@ -61,23 +81,12 @@ export class ClickOutsideDirective implements OnInit, OnDestroy, OnChanges {
         }
       }
     }
-
-    if (this.attachOutsideOnClick) {
-      this._el.nativeElement.addEventListener('click', this._initOnClickBody);
-      this._el.nativeElement.addEventListener('touchstart', this._initOnClickBody);
-    } else {
-      this._initOnClickBody();
-    }
   }
 
-  /** @internal */
-  private _initOnClickBody() {
-    this._document.body.addEventListener('click', this._onClickBody);
-    this._document.body.addEventListener('touchstart', this._onClickBody);
-  }
-
-  /** @internal */
   private _onClickBody(e: Event) {
+    if (this.excludebeforeclick) {
+      this._excludeCheck();
+    }
     if (!this._el.nativeElement.contains(e.target) && !this._shouldExclude(e.target)) {
       this.clickOutside.emit(e);
 


### PR DESCRIPTION
I added some new configuration options. They are outlined in the README.md

Basically, with `[excludebeforeclick]="true"` you can ensure that elements added to the DOM after clickOutside is initialized are added to the exclude list

And `[clickoutsideevents]` allows customization of which events will trigger a "click" outside. See the README for a couple examples. I removed my last PR's touch by default. 